### PR TITLE
Add ability to define whether to use underscores

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,8 @@ var defaults = {
   namespace: null,
   sequelize: null,
   exclude: [],
+  table_underscored: true,
+  underscored: true, // False by default for Sequelize, but true here to not break Backwards Compatibility
   versionAttributes: versionAttributes
 };
 
@@ -101,7 +103,9 @@ function Version(model, customOptions) {
   var prefix = options.prefix,
       suffix = options.suffix,
       namespace = options.namespace,
-      exclude = options.exclude;
+      exclude = options.exclude,
+      table_underscored = options.table_underscored,
+      underscored = options.underscored;
 
 
   if (isEmpty(prefix) && isEmpty(suffix)) {
@@ -119,10 +123,10 @@ function Version(model, customOptions) {
   var cloneModelAttrs = cloneAttrs(model, attrsToClone, exclude);
   var versionModelAttrs = Object.assign({}, cloneModelAttrs, versionAttrs);
 
-  var tableName = '' + (prefix ? prefix + '_' : '') + (model.options.tableName || model.name) + (suffix ? '_' + suffix : '');
+  var tableName = '' + (prefix ? '' + prefix + (table_underscored ? '_' : '') : '') + (model.options.tableName || model.name) + (suffix ? '' + (table_underscored ? '_' : '') + suffix : '');
 
-  var versionFieldType = attributePrefix + '_type';
-  var versionFieldTimestamp = attributePrefix + '_timestamp';
+  var versionFieldType = '' + attributePrefix + (underscored ? '_t' : 'T') + 'ype';
+  var versionFieldTimestamp = '' + attributePrefix + (underscored ? '_t' : 'T') + 'imestamp';
 
   var versionModelOptions = {
     schema: schema,
@@ -188,7 +192,7 @@ function Version(model, customOptions) {
     return versionModel.findAll(versionParams);
   }
 
-  // Sequelize V4 
+  // Sequelize V4
   if (model.prototype) {
     if (!model.prototype.hasOwnProperty('getVersions')) {
       model.prototype.getVersions = getVersions;

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ var defaults = {
   namespace: null,
   sequelize: null,
   exclude: [],
-  table_underscored: true,
+  tableUnderscored: true,
   underscored: true, // False by default for Sequelize, but true here to not break Backwards Compatibility
   versionAttributes: versionAttributes
 };
@@ -104,7 +104,7 @@ function Version(model, customOptions) {
       suffix = options.suffix,
       namespace = options.namespace,
       exclude = options.exclude,
-      table_underscored = options.table_underscored,
+      tableUnderscored = options.tableUnderscored,
       underscored = options.underscored;
 
 
@@ -123,7 +123,7 @@ function Version(model, customOptions) {
   var cloneModelAttrs = cloneAttrs(model, attrsToClone, exclude);
   var versionModelAttrs = Object.assign({}, cloneModelAttrs, versionAttrs);
 
-  var tableName = '' + (prefix ? '' + prefix + (table_underscored ? '_' : '') : '') + (model.options.tableName || model.name) + (suffix ? '' + (table_underscored ? '_' : '') + suffix : '');
+  var tableName = '' + (prefix ? '' + prefix + (tableUnderscored ? '_' : '') : '') + (model.options.tableName || model.name) + (suffix ? '' + (tableUnderscored ? '_' : '') + suffix : '');
 
   var versionFieldType = '' + attributePrefix + (underscored ? '_t' : 'T') + 'ype';
   var versionFieldTimestamp = '' + attributePrefix + (underscored ? '_t' : 'T') + 'imestamp';

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ const defaults = {
   namespace: null,
   sequelize: null,
   exclude: [],
-  table_underscored: true,
+  tableUnderscored: true,
   underscored: true, // False by default for Sequelize, but true here to not break Backwards Compatibility
   versionAttributes,
 };
@@ -103,7 +103,7 @@ function Version(model, customOptions) {
     suffix,
     namespace,
     exclude,
-    table_underscored,
+    tableUnderscored,
     underscored,
   } = options;
 
@@ -122,7 +122,7 @@ function Version(model, customOptions) {
   const cloneModelAttrs = cloneAttrs(model, attrsToClone, exclude);
   const versionModelAttrs = Object.assign({}, cloneModelAttrs, versionAttrs);
 
-  const tableName = `${prefix ? `${prefix}${table_underscored ? '_' : ''}` : ''}${model.options.tableName || model.name}${suffix ? `${table_underscored ? '_' : ''}${suffix}` : ''}`;
+  const tableName = `${prefix ? `${prefix}${tableUnderscored ? '_' : ''}` : ''}${model.options.tableName || model.name}${suffix ? `${tableUnderscored ? '_' : ''}${suffix}` : ''}`;
 
   const versionFieldType = `${attributePrefix}${underscored ? '_t' : 'T'}ype`;
   const versionFieldTimestamp = `${attributePrefix}${underscored ? '_t' : 'T'}imestamp`;

--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,8 @@ const defaults = {
   namespace: null,
   sequelize: null,
   exclude: [],
+  table_underscored: true,
+  underscored: true, // False by default for Sequelize, but true here to not break Backwards Compatibility
   versionAttributes,
 };
 
@@ -101,6 +103,8 @@ function Version(model, customOptions) {
     suffix,
     namespace,
     exclude,
+    table_underscored,
+    underscored,
   } = options;
 
   if (isEmpty(prefix) && isEmpty(suffix)){
@@ -117,11 +121,11 @@ function Version(model, customOptions) {
 
   const cloneModelAttrs = cloneAttrs(model, attrsToClone, exclude);
   const versionModelAttrs = Object.assign({}, cloneModelAttrs, versionAttrs);
-  
-  const tableName = `${prefix ? `${prefix}_` : ''}${model.options.tableName || model.name}${suffix ? `_${suffix}`:''}`;
 
-  const versionFieldType = `${attributePrefix}_type`;
-  const versionFieldTimestamp = `${attributePrefix}_timestamp`;
+  const tableName = `${prefix ? `${prefix}${table_underscored ? '_' : ''}` : ''}${model.options.tableName || model.name}${suffix ? `${table_underscored ? '_' : ''}${suffix}` : ''}`;
+
+  const versionFieldType = `${attributePrefix}${underscored ? '_t' : 'T'}ype`;
+  const versionFieldTimestamp = `${attributePrefix}${underscored ? '_t' : 'T'}imestamp`;
 
   const versionModelOptions = {
     schema,
@@ -176,7 +180,7 @@ function Version(model, customOptions) {
     return versionModel.findAll(versionParams);
   }
 
-  // Sequelize V4 
+  // Sequelize V4
   if (model.prototype){
     if (!model.prototype.hasOwnProperty('getVersions')){
       model.prototype.getVersions = getVersions;


### PR DESCRIPTION
By default, Sequelize doesn't use underscores unless told to in field names
however, this module currently assumes that they do.

This change introduces two options:-

 * `table_underscore` - enables/disables underscores in table names
 * `underscore` - enables/disables underscores in (added) field names