### PR TITLE
Take tableName pluralisation in to account

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ function Version(model, customOptions) {
   const attributePrefix = options.attributePrefix || options.prefix;
   const tableName = `${
     prefix ? `${prefix}${tableUnderscored ? '_' : ''}` : ''
-  }${model.options.tableName || model.name}${
+  }${model.options.tableName || model.options.freezeTableName ? model.name : `${model.name}s`}${
     suffix ? `${tableUnderscored ? '_' : ''}${suffix}` : ''
   }`;
   const versionFieldType = `${attributePrefix}${underscored ? '_t' : 'T'}ype`;


### PR DESCRIPTION
When a model is defined without a specified `tableName` sequelize will pluralise model name, unless you have `freezeTablename: true`. This change takes that in to account, and will pluralise the table name in cases where it should.

This was causing issues where `Version` would look for tables that didn't exist, and the codebase was using a mix of models with `tablename` and `freezeTablename` properties set inconsistently.